### PR TITLE
Urshofer patch 1

### DIFF
--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -103,6 +103,28 @@ class Compiler extends Options
     }
 
     /**
+     * Return code wrapped in PHP tags.
+     *
+     * @param string code to wrap.
+     * @return string
+     */
+    public function wrapInPhp($code)
+    {
+        return '<?php ' . $code . ' ' . $this->closingTag();
+    }
+
+    /**
+     * Return code wrapped out of a PHP code.
+     *
+     * @param string code to wrap.
+     * @return string
+     */
+    public function wrapOutPhp($code)
+    {
+        return ' ' . $this->closingTag() . $code . '<?php ';
+    }
+
+    /**
      * @param $method
      * @param $arguments
      *
@@ -309,19 +331,17 @@ class Compiler extends Options
      *
      * @return string
      */
-    protected function createPhpBlock($code, $statements = null)
+    protected function renderPhpStatements($code, $statements = null)
     {
         if ($statements === null) {
-            return '<?php ' . $code . ' ' . $this->closingTag();
+            return $code;
         }
 
         $codeFormat = array_pop($statements);
         array_unshift($codeFormat, $code);
 
         if (count($statements) === 0) {
-            $phpString = call_user_func_array('sprintf', $codeFormat);
-
-            return '<?php ' . $phpString . ' ' . $this->closingTag();
+            return call_user_func_array('sprintf', $codeFormat);
         }
 
         $stmtString = '';
@@ -332,11 +352,18 @@ class Compiler extends Options
         $stmtString .= $this->newline() . $this->indent();
         $stmtString .= call_user_func_array('sprintf', $codeFormat);
 
-        $phpString = '<?php ';
-        $phpString .= $stmtString;
-        $phpString .= $this->newline() . $this->indent() . ' ' . $this->closingTag();
+        return $stmtString . $this->newline() . $this->indent();
+    }
 
-        return $phpString;
+    /**
+     * @param      $code
+     * @param null $statements
+     *
+     * @return string
+     */
+    protected function createPhpBlock($code, $statements = null)
+    {
+        return $this->wrapInPhp($this->renderPhpStatements($code, $statements));
     }
 
     /**

--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -106,6 +106,7 @@ class Compiler extends Options
      * Return code wrapped in PHP tags.
      *
      * @param string code to wrap.
+     *
      * @return string
      */
     public function wrapInPhp($code)
@@ -117,6 +118,7 @@ class Compiler extends Options
      * Return code wrapped out of a PHP code.
      *
      * @param string code to wrap.
+     *
      * @return string
      */
     public function wrapOutPhp($code)

--- a/src/Jade/Filter/Php.php
+++ b/src/Jade/Filter/Php.php
@@ -23,13 +23,13 @@ class Php implements FilterInterface
         foreach ($node->block->nodes as $n) {
             if (isset($n->value)) {
                 $data .= preg_match('/^[[:space:]]*\|(?!\|)(.*)/', $n->value, $m)
-                    ? ' ?> ' . $m[1] . '<?php '
+                    ? $compiler->wrapOutPhp($m[1])
                     : $n->value . "\n";
                 continue;
             }
-            $data .= ' ?> ' . $compiler->subCompiler()->compile($n) . '<?php ';
+            $data .= $compiler->wrapOutPhp($compiler->subCompiler()->compile($n));
         }
 
-        return $data ? '<?php ' . $data . ' ?>' : $data;
+        return $data ? $compiler->wrapInPhp($data) : $data;
     }
 }

--- a/tests/features/cache.php
+++ b/tests/features/cache.php
@@ -132,7 +132,7 @@ class JadeCacheTest extends PHPUnit_Framework_TestCase
         $cachedFile = realpath($phpFiles[0]);
         $this->assertFalse(!$cachedFile, 'The cached file should now exist.');
         $this->assertSame($stream, $jade->stream($jade->compile($file)), 'Should return the stream of attrs.jade.');
-        $this->assertSame(substr($stream, strlen($start)), file_get_contents($cachedFile), 'The cached file should contains the same contents.');
+        $this->assertStringEqualsFile($cachedFile, substr($stream, strlen($start)), 'The cached file should contains the same contents.');
         touch($file, time() - 3600);
         $path = $jade->cache($file);
         $this->assertSame(realpath($path), $cachedFile, 'The cached file should be used instead if untouched.');

--- a/tests/features/filter.php
+++ b/tests/features/filter.php
@@ -122,4 +122,94 @@ h1
 
         $this->assertSame($expected, $actual, 'In-line filter');
     }
+
+    /**
+     * @group php-filter-prettyprint
+     */
+    public function testPhpFilterWithoutPrettyprint()
+    {
+        $jade = new Jade();
+        $actual = $jade->render('
+h1
+    :php
+        |BAR-
+        echo 6 * 7
+        |-BAR
+');
+        $expected = '<h1>BAR-42-BAR</h1>';
+
+        $this->assertSame($expected, $actual, 'Block filter');
+
+        $actual = $jade->render('
+h1
+    span BAR-
+    :php
+        echo 6 * 7
+    span -BAR
+');
+        $expected = '<h1><span>BAR-</span>42<span>-BAR</span></h1>';
+
+        $this->assertSame($expected, $actual, 'Block filter and span');
+
+        $actual = $jade->render('
+h1
+    | BAR-
+    :php echo 6 * 7
+    | -BAR
+');
+        $expected = '<h1>BAR-42-BAR</h1>';
+
+        $this->assertSame($expected, $actual, 'One-line filter');
+
+        $actual = $jade->render('h1 BAR-#[:php echo 6 * 7]-BAR');
+        $expected = '<h1>BAR-42-BAR</h1>';
+
+        $this->assertSame($expected, $actual, 'In-line filter');
+    }
+
+    /**
+     * @group php-filter-prettyprint
+     */
+    public function testPhpFilterWithPrettyprint()
+    {
+        $jade = new Jade(array(
+            'prettyprint' => true,
+        ));
+        $actual = trim($jade->render('
+h1
+    :php
+        | BAR-
+        echo 6 * 7
+        | -BAR
+'));
+        $expected = '/^<h1>\n    BAR-42\s+-BAR\s*\n<\/h1>$/';
+
+        $this->assertRegExp($expected, $actual, 'Block filter');
+
+        $actual = trim($jade->render('
+h1
+    span BAR-
+    :php
+        echo 6 * 7
+    span -BAR
+'));
+        $expected = '/^<h1>\s+<span>BAR-<\/span>\s+42\s+<span>-BAR<\/span><\/h1>$/';
+
+        $this->assertRegExp($expected, $actual, 'Block filter and span');
+
+        $actual = trim($jade->render('
+h1
+    | BAR-
+    :php echo 6 * 7
+    | -BAR
+'));
+        $expected = '/^<h1>\s+BAR-\s+42\s+-BAR\s*<\/h1>$/';
+
+        $this->assertRegExp($expected, $actual, 'One-line filter');
+
+        $actual = $jade->render('h1 BAR-#[:php echo 6 * 7]-BAR');
+        $expected = '/^<h1>\s+BAR-\s+42\s+-BAR\s*<\/h1>$/';
+
+        $this->assertRegExp($expected, $actual, 'In-line filter');
+    }
 }


### PR DESCRIPTION
Hi,

I propose a method where the filter no longer handle the PHP wrapping but use dedicated methods from the compiler with a bit of refactorization and some unit tests.

So with prettyprint = false, you should have <span> sticky concatenation and with prettyprint = true, you get spaces between them.
